### PR TITLE
Support generic data in ContentFieldsAPIResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ package main
 import (
 	"github.com/buttercms/buttercms-go"
 	"fmt"
+	"encoding/json"
 )
 
 func main() {
@@ -112,6 +113,20 @@ func main() {
 			}
 		}
 	}
+
+	contentParams := map[string]string{}
+	contentKeys := []string{"somethings"}
+	contentResp, err := ButterCMS.GetContentFields(contentKeys, contentParams)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	j, err := json.Marshal(contentResp)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	fmt.Println(string(j))
 }
 ```
 

--- a/api.go
+++ b/api.go
@@ -72,5 +72,5 @@ type FeedAPIResponse struct {
 
 // Content Fields
 type ContentFieldsAPIResponse struct {
-	Data map[string]string `json:"data"`
+	Data map[string]interface{} `json:"data"`
 }


### PR DESCRIPTION
By using a generic `interface{}` instead of a `string` ContentFieldsAPIResponse
type can be used to unmarshall ContentFields with nested objects, not
just strings.

For example, this kind of response would throw an error before:
```json
{
  "data": [
    {
      "name": "some name",
      "complex-object": {
         "content": "content"
      }
    }
  ]
}
```